### PR TITLE
[Starts #163698192] Add failing test for GET /offices/<office-id>/ en…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 Politico API(ADC CHALLENGE 2)
 [![Maintainability](https://api.codeclimate.com/v1/badges/1175493c02385a0e8248/maintainability)](https://codeclimate.com/github/Egunza-dev/ch2api/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/1175493c02385a0e8248/test_coverage)](https://codeclimate.com/github/Egunza-dev/ch2api/test_coverage)
-[![Coverage Status](https://coveralls.io/repos/github/Egunza-dev/ch2api/badge.svg?branch=master)](https://coveralls.io/github/Egunza-dev/ch2api?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/Egunza-dev/ch2api/badge.svg?branch=develop)](https://coveralls.io/github/Egunza-dev/ch2api?branch=develop)
 

--- a/app/tests/test_offices.py
+++ b/app/tests/test_offices.py
@@ -26,6 +26,17 @@ class TestOfficesEndpoints(unittest.TestCase):
         self.assertIn('President', str(res.data))
 
 
+    def test_api_can_get_office_by_id(self):
+        """Test endpoint that fetches a particular office"""
+
+        res = self.client().get('/api/v1/offices/2')
+        self.assertEqual(res.status_code, 200)
+        self.assertIn('legislative', str(res.data))
+
+
+     
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
_What the PR does:_  
Adds a failing test for GET /offices/office-id/ api endpoint  
_Description_  
Sets the parameters that is expected in the implementation of the GET /offices/office-id/ api endpoint  
_Pivotal Tracker stroty:_  
#163698192