### PR TITLE
[Starts #163689898] Add failing test for POST /offices endpoint.

### DIFF
--- a/app/tests/test_offices.py
+++ b/app/tests/test_offices.py
@@ -33,6 +33,14 @@ class TestOfficesEndpoints(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertIn('legislative', str(res.data))
 
+    
+    def test_api_can_create_office(self):
+        """Test endpoint that posts a particular office"""
+
+        res = self.client().post(path='/api/v1/offices/', json=self.office, content_type='application/json')
+        self.assertEqual(res.status_code, 201)
+        self.assertIn('Secretary of State', str(res.data))
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
_What the PR does:_  
Adds a failing test for POST /offices api endpoint  
_Description_  
Sets the parameters that is expected in the implementation of the POST /offices api endpoint  
_Pivotal Tracker stroty:_  
 #163689898