### PR TITLE
[Starts #163789278] Add failing test for POST /parties endpoint.

### DIFF
--- a/app/tests/test_parties.py
+++ b/app/tests/test_parties.py
@@ -41,3 +41,11 @@ class TestPartiesEndpoints(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertIn('Democratic Party', str(res.data))
 
+
+    def test_api_can_create_party(self):
+        """Test endpoint that posts a particular party"""
+        
+        res = self.client().post('/api/v1/parties/', json=self.party)
+        self.assertEqual(res.status_code, 201)
+        self.assertIn('UCL Party', str(res.data))
+


### PR DESCRIPTION
_What the PR does:_  
Adds a failing test for POST /parties api endpoint  
_Description_  
Sets the parameters that is expected in the implementation of the POST /parties api endpoint  
_Pivotal Tracker stroty:_
#163789278